### PR TITLE
Revert perf regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+Status
+======
+
+| Language | CircleCI |
+|:--------:|:------:|
+| ![GitHub top language](https://img.shields.io/github/languages/top/haskell-numerics/random-fu.svg) | [![Build Status](https://circleci.com/gh/haskell-numerics/random-fu.svg?style=svg)](https://circleci.com/gh/haskell-numerics/random-fu) |
+
 Random-fu
 =========
 
@@ -25,35 +32,18 @@ To use the system, you'll typically want import at least two modules: `Data.Rand
 
     import Data.Random
     import System.Random.MWC (create)
-    
+
     logNormal :: Double -> Double -> RVar Double
     logNormal mu sigmaSq = do
         x <- normal mu sigmaSq
         return (exp x)
-    
+
     main = do
         mwc <- create
         y <- sampleFrom mwc (logNormal 5 1)
         print y
 
-Installation
-============
+Developers
+==========
 
-Get the latest release from Hackage:
-
-    cabal install random-fu
-
-Or a bleeding-edge version from github:
-
-    git clone https://github.com/mokus0/random-fu.git
-    cd random-fu
-    (cd random-source; cabal install)
-    (cd rvar;          cabal install)
-    (cd random-fu;     cabal install)
-
-Status
-======
-
-| Language | CircleCI |
-|:--------:|:------:|
-| ![GitHub top language](https://img.shields.io/github/languages/top/haskell-numerics/random-fu.svg) | [![Build Status](https://circleci.com/gh/haskell-numerics/random-fu.svg?style=svg)](https://circleci.com/gh/haskell-numerics/random-fu) |
+Ensure that you run the benchmarks before making a PR e.g. `stack bench` and then run the resulting bindary

--- a/release.nix
+++ b/release.nix
@@ -1,10 +1,15 @@
 let
-  overlay = self: super:
-{
-  random-fu     = self.haskellPackages.callPackage ./random-fu { rvar = self.rvar; };
-  random-source = self.haskellPackages.callPackage ./random-source { };
-  rvar          = self.haskellPackages.callPackage ./rvar { random-source = self.random-source; };
-};
+  myHaskellPackageOverlay = self: super: {
+    myHaskellPackages = super.haskellPackages.override {
+    overrides = hself: hsuper: rec {
+    random-fu     = super.haskell.lib.disableLibraryProfiling (hself.callPackage  ./random-fu { });
+    random-source = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./random-source { });
+    rvar          = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./rvar { });
+      };
+    };
+  };
+
+  nixpkgs = import <nixpkgs> { overlays = [ myHaskellPackageOverlay ]; };
 
 in
 

--- a/release.nix
+++ b/release.nix
@@ -13,10 +13,8 @@ let
 
 in
 
-{ nixpkgs ? import <nixpkgs> { overlays = [ overlay ]; } }:
-
-nixpkgs.haskellPackages.callPackage ./tests/speed {
-  random-source = nixpkgs.random-source;
-  random-fu     = nixpkgs.random-fu;
+nixpkgs.myHaskellPackages.callPackage ./tests/speed {
+  random-source = nixpkgs.myHaskellPackages.random-source;
+  random-fu     = nixpkgs.myHaskellPackages.random-fu;
 }
 


### PR DESCRIPTION
Sadly this https://github.com/haskell-numerics/random-fu/pull/45 caused a significant regression and this reverts it.

| Test Name                                                      | Current Mean | Mean with PR | Change (%) |
|----------------------------------------------------------------|--------------|--------------|------------|
| dists/PureMT/uniform/Double/single sample                      |     3.34E-08 |     3.68E-07 |    -90.91% |
| dists/PureMT/uniform/Double/sum of samples (implicit rvar)     |     2.05E-03 |     2.32E-02 |    -91.19% |
| dists/PureMT/uniform/Double/sum of samples (explicit rvar)     |     2.25E-03 |     2.35E-02 |    -90.42% |
| dists/PureMT/uniform/Double/sample of sum                      |     3.25E-03 |     2.55E-02 |    -87.25% |
| dists/PureMT/uniform/Double/array of samples                   |     2.57E-03 |     2.43E-02 |    -89.39% |
| dists/PureMT/uniform/Double/RVarT IO arrays                    |     5.03E-03 |     2.90E-02 |    -82.63% |
| dists/PureMT/uniform/Int/single sample                         |     2.38E-07 |     4.87E-07 |    -51.07% |
| dists/PureMT/uniform/Int/sum of samples (implicit rvar)        |     1.48E-02 |     3.05E-02 |    -51.56% |
| dists/PureMT/uniform/Int/sum of samples (explicit rvar)        |     1.50E-02 |     3.04E-02 |    -50.68% |
| dists/PureMT/uniform/Int/sample of sum                         |     1.47E-02 |     2.96E-02 |    -50.36% |
| dists/PureMT/uniform/Int/array of samples                      |     2.18E-02 |     3.61E-02 |    -39.43% |
| dists/PureMT/uniform/Int/RVarT IO arrays                       |     1.77E-02 |     3.33E-02 |    -46.97% |
| dists/PureMT/stdUniform/Double/single sample                   |     2.68E-08 |     4.21E-07 |    -93.63% |
| dists/PureMT/stdUniform/Double/sum of samples (implicit rvar)  |     1.54E-03 |     2.33E-02 |    -93.39% |
| dists/PureMT/stdUniform/Double/sum of samples (explicit rvar)  |     1.55E-03 |     2.48E-02 |    -93.77% |
| dists/PureMT/stdUniform/Double/sample of sum                   |     2.66E-03 |     2.67E-02 |    -90.05% |
| dists/PureMT/stdUniform/Double/array of samples                |     1.99E-03 |     2.63E-02 |    -92.44% |
| dists/PureMT/stdUniform/Double/RVarT IO arrays                 |     4.72E-03 |     3.25E-02 |    -85.46% |
| dists/PureMT/stdUniform/Int/single sample                      |     2.52E-08 |     7.12E-07 |    -96.45% |
| dists/PureMT/stdUniform/Int/sum of samples (implicit rvar)     |     1.42E-03 |     4.34E-02 |    -96.73% |
| dists/PureMT/stdUniform/Int/sum of samples (explicit rvar)     |     1.34E-03 |     4.18E-02 |    -96.79% |
| dists/PureMT/stdUniform/Int/sample of sum                      |     2.67E-03 |     5.12E-02 |    -94.78% |
| dists/PureMT/stdUniform/Int/array of samples                   |     1.81E-03 |     4.33E-02 |    -95.82% |
| dists/PureMT/stdUniform/Int/RVarT IO arrays                    |     4.35E-03 |     4.98E-02 |    -91.27% |
| dists/PureMT/poisson/Double/single sample                      |     3.64E-07 |     1.97E-06 |    -81.50% |
| dists/PureMT/poisson/Double/sum of samples (implicit rvar)     |     2.32E-02 |  0.123280996 |    -81.17% |
| dists/PureMT/poisson/Double/sum of samples (explicit rvar)     |     2.35E-02 |  0.124861048 |    -81.20% |
| dists/PureMT/poisson/Double/sample of sum                      |     2.41E-02 |  0.123237969 |    -80.44% |
| dists/PureMT/poisson/Double/array of samples                   |     3.32E-02 |  0.129579289 |    -74.37% |
| dists/PureMT/poisson/Double/RVarT IO arrays                    |     2.64E-02 |  0.119814662 |    -78.00% |
| dists/PureMT/poisson/Int/single sample                         |     3.88E-07 |     1.82E-06 |    -78.72% |
| dists/PureMT/poisson/Int/sum of samples (implicit rvar)        |     2.47E-02 |   0.11587482 |    -78.70% |
| dists/PureMT/poisson/Int/sum of samples (explicit rvar)        |     2.30E-02 |  0.114998965 |    -80.02% |
| dists/PureMT/poisson/Int/sample of sum                         |     2.29E-02 |   0.12210896 |    -81.27% |
| dists/PureMT/poisson/Int/array of samples                      |     3.25E-02 |  0.127312738 |    -74.47% |
| dists/PureMT/poisson/Int/RVarT IO arrays                       |     2.52E-02 |   0.11960705 |    -78.93% |
| dists/PureMT/binomial 10/Double/single sample                  |     6.59E-07 |     3.99E-06 |    -83.46% |
| dists/PureMT/binomial 10/Double/sum of samples (implicit rvar) |     4.31E-02 |  0.258988272 |    -83.37% |
| dists/PureMT/binomial 10/Double/sum of samples (explicit rvar) |     4.44E-02 |  0.255071938 |    -82.58% |
| dists/PureMT/binomial 10/Double/sample of sum                  |  0.411518783 |  0.670825859 |    -38.65% |
| dists/PureMT/binomial 10/Double/array of samples               |  0.101623275 |  0.326977502 |    -68.92% |
| dists/PureMT/binomial 10/Double/RVarT IO arrays                |     5.95E-02 |  0.270118585 |    -77.97% |
| dists/PureMT/binomial 10/Int/single sample                     |     6.61E-07 |     4.01E-06 |    -83.54% |
| dists/PureMT/binomial 10/Int/sum of samples (implicit rvar)    |     4.30E-02 |  0.256739649 |    -83.25% |
| dists/PureMT/binomial 10/Int/sum of samples (explicit rvar)    |     4.33E-02 |  0.257709118 |    -83.22% |
| dists/PureMT/binomial 10/Int/sample of sum                     |  0.292883399 |  0.501134391 |    -41.56% |
| dists/PureMT/binomial 10/Int/array of samples                  |     9.02E-02 |  0.316737005 |    -71.52% |
| dists/PureMT/binomial 10/Int/RVarT IO arrays                   |     8.17E-02 |  0.302595815 |    -73.01% |
| dists/PureMT/stdNormal/single sample                           |     7.10E-08 |     6.86E-07 |    -89.65% |
| dists/PureMT/stdNormal/sum of samples (implicit rvar)          |     4.41E-03 |     4.38E-02 |    -89.93% |
| dists/PureMT/stdNormal/sum of samples (explicit rvar)          |     4.45E-03 |     4.40E-02 |    -89.89% |
| dists/PureMT/stdNormal/sample of sum                           |     5.15E-03 |     4.54E-02 |    -88.67% |
| dists/PureMT/stdNormal/array of samples                        |     6.73E-03 |     4.73E-02 |    -85.77% |
| dists/PureMT/stdNormal/RVarT IO arrays                         |     7.15E-03 |     4.74E-02 |    -84.89% |
| dists/PureMT/exponential/single sample                         |     3.81E-08 |     3.69E-07 |    -89.66% |
| dists/PureMT/exponential/sum of samples (implicit rvar)        |     2.20E-03 |     2.33E-02 |    -90.55% |
| dists/PureMT/exponential/sum of samples (explicit rvar)        |     2.25E-03 |     2.37E-02 |    -90.47% |
| dists/PureMT/exponential/sample of sum                         |     5.80E-03 |     2.88E-02 |    -79.88% |
| dists/PureMT/exponential/array of samples                      |     2.76E-03 |     2.43E-02 |    -88.62% |
| dists/PureMT/exponential/RVarT IO arrays                       |     7.46E-03 |     3.10E-02 |    -75.96% |
| dists/PureMT/beta/single sample                                |     4.20E-07 |     2.53E-06 |    -83.41% |
| dists/PureMT/beta/sum of samples (implicit rvar)               |     2.65E-02 |  0.161357275 |    -83.55% |
| dists/PureMT/beta/sum of samples (explicit rvar)               |     2.69E-02 |  0.165472193 |    -83.75% |
| dists/PureMT/beta/sample of sum                                |     2.79E-02 |  0.164298111 |    -83.01% |
| dists/PureMT/beta/array of samples                             |     4.01E-02 |  0.175814198 |    -77.17% |
| dists/PureMT/beta/RVarT IO arrays                              |     3.34E-02 |  0.167400184 |    -80.03% |
| dists/PureMT/gamma/single sample                               |     1.48E-07 |     1.16E-06 |    -87.22% |
| dists/PureMT/gamma/sum of samples (implicit rvar)              |     8.16E-03 |     7.35E-02 |    -88.90% |
| dists/PureMT/gamma/sum of samples (explicit rvar)              |     8.16E-03 |     7.35E-02 |    -88.90% |
| dists/PureMT/gamma/sample of sum                               |     9.40E-03 |     7.45E-02 |    -87.38% |
| dists/PureMT/gamma/array of samples                            |     1.86E-02 |     8.59E-02 |    -78.28% |
| dists/PureMT/gamma/RVarT IO arrays                             |     1.14E-02 |     7.83E-02 |    -85.38% |
| dists/PureMT/triangular/single sample                          |     1.24E-07 |     4.88E-07 |    -74.54% |
| dists/PureMT/triangular/sum of samples (implicit rvar)         |     7.90E-03 |     3.19E-02 |    -75.26% |
| dists/PureMT/triangular/sum of samples (explicit rvar)         |     7.90E-03 |     3.16E-02 |    -74.98% |
| dists/PureMT/triangular/sample of sum                          |     8.54E-03 |     3.23E-02 |    -73.54% |
| dists/PureMT/triangular/array of samples                       |     1.54E-02 |     3.95E-02 |    -60.93% |
| dists/PureMT/triangular/RVarT IO arrays                        |     1.06E-02 |     3.53E-02 |    -70.01% |
| dists/PureMT/rayleigh/single sample                            |     1.32E-07 |     5.00E-07 |    -73.70% |
| dists/PureMT/rayleigh/sum of samples (implicit rvar)           |     8.60E-03 |     3.19E-02 |    -73.04% |
| dists/PureMT/rayleigh/sum of samples (explicit rvar)           |     8.38E-03 |     3.19E-02 |    -73.75% |
| dists/PureMT/rayleigh/sample of sum                            |     9.19E-03 |     3.32E-02 |    -72.31% |
| dists/PureMT/rayleigh/array of samples                         |     1.34E-02 |     3.83E-02 |    -65.06% |
| dists/PureMT/rayleigh/RVarT IO arrays                          |     1.11E-02 |     3.56E-02 |    -68.90% |
| dists/PureMT/dirichlet                                         |     2.88E-02 |     9.68E-02 |    -70.22% |
| dists/PureMT/multinomial/many p/small n                        |     9.45E-03 |     3.41E-02 |    -72.31% |
| dists/PureMT/multinomial/many p/medium n                       |     9.05E-02 |  0.328863485 |    -72.49% |
| dists/PureMT/multinomial/many p/large n                        |  0.205577328 |  0.730400811 |    -71.85% |
| dists/PureMT/multinomial/few p/small n                         |     8.36E-03 |     3.38E-02 |    -75.29% |
| dists/PureMT/multinomial/few p/medium n                        |     8.60E-02 |  0.306485231 |    -71.94% |
| dists/PureMT/multinomial/few p/large n                         |  0.190808324 |  0.680886071 |    -71.98% |
| dists/PureMT/shuffle                                           |  0.108362626 |  0.127708992 |    -15.15% |
