### PR TITLE
Random 1.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: random-fu/
+          random-source/
+          rvar/
+	  tests/speed/

--- a/random-fu/random-fu.cabal
+++ b/random-fu/random-fu.cabal
@@ -1,5 +1,5 @@
 name:                   random-fu
-version:                0.2.7.4
+version:                0.2.7.5
 stability:              provisional
 
 cabal-version:          >= 1.6
@@ -91,7 +91,7 @@ Library
 
   build-depends:        math-functions,
                         monad-loops >= 0.3.0.1,
-                        random,
+                        random >= 1.2.0,
                         random-shuffle,
                         random-source == 0.3.*,
                         rvar == 0.2.*,

--- a/random-source/random-source.cabal
+++ b/random-source/random-source.cabal
@@ -82,7 +82,7 @@ Library
 
   build-depends:        flexible-defaults >= 0.0.0.2,
                         mersenne-random-pure64,
-                        random == 1.2.0,
+                        random >= 1.2.0,
                         stateref >= 0.3 && < 0.4,
                         template-haskell,
                         th-extras,

--- a/random-source/random-source.cabal
+++ b/random-source/random-source.cabal
@@ -1,5 +1,5 @@
 name:                   random-source
-version:                0.3.0.8
+version:                0.3.0.9
 stability:              provisional
 
 cabal-version:          >= 1.6
@@ -82,7 +82,7 @@ Library
 
   build-depends:        flexible-defaults >= 0.0.0.2,
                         mersenne-random-pure64,
-                        random,
+                        random == 1.2.0,
                         stateref >= 0.3 && < 0.4,
                         template-haskell,
                         th-extras,

--- a/release.nix
+++ b/release.nix
@@ -2,23 +2,20 @@ let
   myHaskellPackageOverlay = self: super: {
     myHaskellPackages = super.haskellPackages.override {
     overrides = hself: hsuper: rec {
+        random = hsuper.random_1_2_0;
+        mkDerivation = args: hsuper.mkDerivation (args // {
+          doCheck = false;
+          doHaddock = false;
+        });
+
     random-fu     = super.haskell.lib.disableLibraryProfiling (hself.callPackage  ./random-fu { });
-    random-source = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./random-source { });
+    random-source = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./random-source { random = hsuper.random_1_2_0; });
     rvar          = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./rvar { });
-
-    # random =
-    #     let newRandomSrc = builtins.fetchGit {
-    #       url = "https://github.com/idontgetoutmuch/random.git";
-    #       rev = "8ac2c89c8394555f56ade4eda34051599833e885";
-    #       ref = "v1.2-proposal";
-    #       };
-    #         ran = hself.callCabal2nix "random" newRandomSrc {};
-    #       in
-    #       super.haskell.lib.dontCheck ran;
-
-      };
+    splitmix      = hsuper.splitmix_0_1;
+    MonadRandom   = hsuper.MonadRandom_0_5_2;
     };
   };
+};
 
   nixpkgs = import <nixpkgs> { overlays = [ myHaskellPackageOverlay ]; };
 
@@ -27,7 +24,4 @@ in
 nixpkgs.myHaskellPackages.callPackage ./tests/speed {
   random-source = nixpkgs.myHaskellPackages.random-source;
   random-fu     = nixpkgs.myHaskellPackages.random-fu;
-  # rvar          = nixpkgs.myHaskellPackages.rvar;
-  # random        = nixpkgs.myHaskellPackages.random;
 }
-

--- a/release.nix
+++ b/release.nix
@@ -17,7 +17,11 @@ let
   };
 };
 
-  nixpkgs = import <nixpkgs> { overlays = [ myHaskellPackageOverlay ]; };
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable-2018-06-28";
+    url = "https://github.com/nixos/nixpkgs/archive/056b0df2b614893b15dd696e74d093f6c58590a0.tar.gz";
+    sha256 = "1zjrjk5pfzl1nsii90q1v43cf55jr66igapa8pqgxdg465p186c2";
+}) { overlays = [ myHaskellPackageOverlay ]; };
 
 in
 

--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,17 @@ let
     random-fu     = super.haskell.lib.disableLibraryProfiling (hself.callPackage  ./random-fu { });
     random-source = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./random-source { });
     rvar          = super.haskell.lib.disableLibraryProfiling (hself.callPackage ./rvar { });
+
+    # random =
+    #     let newRandomSrc = builtins.fetchGit {
+    #       url = "https://github.com/idontgetoutmuch/random.git";
+    #       rev = "8ac2c89c8394555f56ade4eda34051599833e885";
+    #       ref = "v1.2-proposal";
+    #       };
+    #         ran = hself.callCabal2nix "random" newRandomSrc {};
+    #       in
+    #       super.haskell.lib.dontCheck ran;
+
       };
     };
   };
@@ -16,5 +27,7 @@ in
 nixpkgs.myHaskellPackages.callPackage ./tests/speed {
   random-source = nixpkgs.myHaskellPackages.random-source;
   random-fu     = nixpkgs.myHaskellPackages.random-fu;
+  # rvar          = nixpkgs.myHaskellPackages.rvar;
+  # random        = nixpkgs.myHaskellPackages.random;
 }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.7
+resolver: lts-16.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -41,7 +41,9 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+- flexible-defaults-0.0.3@sha256:6a7ab000561e1075003cb1053dfbbb4020ae2b02916776d1479c9c3fc82f5d0d,2508
+# allow-newer: true
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/tests/speed/Bench.hs
+++ b/tests/speed/Bench.hs
@@ -24,7 +24,7 @@ import Control.Monad.State
 import qualified Control.Monad.Random as CMR
 import Control.Monad.Trans (lift)
 import Foreign
-import System.Random
+import System.Random hiding (uniform)
 import qualified System.Random.MWC as MWC
 import TestSupport
 import qualified Data.Vector.Unboxed as Vec

--- a/tests/speed/speed-tests.cabal
+++ b/tests/speed/speed-tests.cabal
@@ -1,5 +1,5 @@
 name:                   speed-tests
-version:                0.0.0.1
+version:                0.0.0.2
 stability:              experimental
 
 cabal-version:          >= 1.2
@@ -12,7 +12,8 @@ description:            Various benchmarks for the random-fu library.
 
 flag split-random-fu
 
-Executable random-fu-bench
+executable random-fu-bench
+  type:             exitcode-stdio-1.0
   main-is:              Bench.hs
   build-depends:        base >= 4, criterion, MonadRandom, mtl,
                         stateref, mersenne-random-pure64, mwc-random >= 0.5,


### PR DESCRIPTION
Use random-1.2 to get the following performance increases:


Name | Increase
-- | --
dists/StdGen/uniform/Double/single sample | 185%
dists/StdGen/uniform/Double/sum of   samples (implicit rvar) | 191%
dists/StdGen/uniform/Double/sum of   samples (explicit rvar) | 195%
dists/StdGen/uniform/Double/sample of sum | 155%
dists/StdGen/uniform/Double/array of   samples | 182%
dists/StdGen/uniform/Double/RVarT IO   arrays | 129%
dists/StdGen/uniform/Int/single sample | 51%
dists/StdGen/uniform/Int/sum of samples   (implicit rvar) | 53%
dists/StdGen/uniform/Int/sum of samples   (explicit rvar) | 50%
dists/StdGen/uniform/Int/sample of sum | 49%
dists/StdGen/uniform/Int/array of samples | 34%
dists/StdGen/uniform/Int/RVarT IO arrays | 41%
dists/StdGen/stdUniform/Double/single   sample | 196%
dists/StdGen/stdUniform/Double/sum of   samples (implicit rvar) | 197%
dists/StdGen/stdUniform/Double/sum of   samples (explicit rvar) | 194%
dists/StdGen/stdUniform/Double/sample of   sum | 167%
dists/StdGen/stdUniform/Double/array of   samples | 177%
dists/StdGen/stdUniform/Double/RVarT IO   arrays | 134%
dists/StdGen/stdUniform/Int/single sample | 355%
dists/StdGen/stdUniform/Int/sum of   samples (implicit rvar) | 368%
dists/StdGen/stdUniform/Int/sum of   samples (explicit rvar) | 368%
dists/StdGen/stdUniform/Int/sample of sum | 323%
dists/StdGen/stdUniform/Int/array of   samples | 339%
dists/StdGen/stdUniform/Int/RVarT IO   arrays | 226%
dists/StdGen/poisson/Double/single sample | 90%
dists/StdGen/poisson/Double/sum of   samples (implicit rvar) | 109%
dists/StdGen/poisson/Double/sum of   samples (explicit rvar) | 103%
dists/StdGen/poisson/Double/sample of sum | 95%
dists/StdGen/poisson/Double/array of   samples | 91%
dists/StdGen/poisson/Double/RVarT IO   arrays | 100%
dists/StdGen/poisson/Int/single sample | 113%
dists/StdGen/poisson/Int/sum of samples   (implicit rvar) | 55%
dists/StdGen/poisson/Int/sum of samples   (explicit rvar) | 112%
dists/StdGen/poisson/Int/sample of sum | 124%
dists/StdGen/poisson/Int/array of samples | 84%
dists/StdGen/poisson/Int/RVarT IO arrays | 121%
dists/StdGen/binomial 10/Double/single   sample | 135%
dists/StdGen/binomial 10/Double/sum of   samples (implicit rvar) | 100%
dists/StdGen/binomial 10/Double/sum of   samples (explicit rvar) | 101%
dists/StdGen/binomial 10/Double/sample of   sum | 26%
dists/StdGen/binomial 10/Double/array of   samples | 89%
dists/StdGen/binomial 10/Double/RVarT IO   arrays | 129%
dists/StdGen/binomial 10/Int/single   sample | 126%
dists/StdGen/binomial 10/Int/sum of   samples (implicit rvar) | 132%
dists/StdGen/binomial 10/Int/sum of   samples (explicit rvar) | 152%
dists/StdGen/binomial 10/Int/sample of   sum | 33%
dists/StdGen/binomial 10/Int/array of   samples | 84%
dists/StdGen/binomial 10/Int/RVarT IO   arrays | 96%
dists/StdGen/stdNormal/single sample | 221%
dists/StdGen/stdNormal/sum of samples   (implicit rvar) | 241%
dists/StdGen/stdNormal/sum of samples   (explicit rvar) | 270%
dists/StdGen/stdNormal/sample of sum | 263%
dists/StdGen/stdNormal/array of samples | 198%
dists/StdGen/stdNormal/RVarT IO arrays | 204%
dists/StdGen/exponential/single sample | 154%
dists/StdGen/exponential/sum of samples   (implicit rvar) | 186%
dists/StdGen/exponential/sum of samples   (explicit rvar) | 151%
dists/StdGen/exponential/sample of sum | 112%
dists/StdGen/exponential/array of samples | 165%
dists/StdGen/exponential/RVarT IO arrays | 99%
dists/StdGen/beta/single sample | 180%
dists/StdGen/beta/sum of samples   (implicit rvar) | 165%
dists/StdGen/beta/sum of samples   (explicit rvar) | 176%
dists/StdGen/beta/sample of sum | 149%
dists/StdGen/beta/array of samples | 99%
dists/StdGen/beta/RVarT IO arrays | 128%
dists/StdGen/gamma/single sample | 105%
dists/StdGen/gamma/sum of samples   (implicit rvar) | 190%
dists/StdGen/gamma/sum of samples   (explicit rvar) | 214%
dists/StdGen/gamma/sample of sum | 204%
dists/StdGen/gamma/array of samples | 145%
dists/StdGen/gamma/RVarT IO arrays | 169%
dists/StdGen/triangular/single sample | 79%
dists/StdGen/triangular/sum of samples   (implicit rvar) | 80%
dists/StdGen/triangular/sum of samples   (explicit rvar) | 77%
dists/StdGen/triangular/sample of sum | 91%
dists/StdGen/triangular/array of samples | 48%
dists/StdGen/triangular/RVarT IO arrays | 77%
dists/StdGen/rayleigh/single sample | 78%
dists/StdGen/rayleigh/sum of samples   (implicit rvar) | 77%
dists/StdGen/rayleigh/sum of samples   (explicit rvar) | 85%
dists/StdGen/rayleigh/sample of sum | 75%
dists/StdGen/rayleigh/array of samples | 56%
dists/StdGen/rayleigh/RVarT IO arrays | 60%
dists/StdGen/dirichlet | 106%
dists/StdGen/multinomial/many p/small n | 81%
dists/StdGen/multinomial/many p/medium n | 96%
dists/StdGen/multinomial/many p/large n | 131%
dists/StdGen/multinomial/few p/small n | 98%
dists/StdGen/multinomial/few p/medium n | 113%
dists/StdGen/multinomial/few p/large n | 118%
dists/StdGen/shuffle | 2%

