### PR TITLE
Fix build of random-source for GHC 8.4 and below

### DIFF
--- a/random-source/src/Data/Random/Source/RandomGen.hs
+++ b/random-source/src/Data/Random/Source/RandomGen.hs
@@ -54,6 +54,8 @@ atomicModifyReference' ref getR =
 -- Additionally, the standard mtl state monads have 'MonadRandom' instances
 -- which do precisely that, allowing an easy conversion of 'RVar's and
 -- other 'Distribution' instances to \"pure\" random variables.
+{-# INLINABLE getRandomPrimFromRandomGenState #-}
+-- making the function inlinable enables specialization in other modules
 getRandomPrimFromRandomGenState :: forall g m a. (RandomGen g, MonadState g m) => Prim a -> m a
 getRandomPrimFromRandomGenState = genPrim
     where


### PR DESCRIPTION
Two specializations in Data.Random.Source.StdGen cause a scary panic in ghc < 8.6:

```
[11 of 11] Compiling Data.Random.Source.StdGen ( src/Data/Random/Source/StdGen.hs, dist/dist-sandbox-9d371a75/build/Data/Random/Source/StdGen.o )

src/Data/Random/Source/StdGen.hs:62:1: warning:
    You cannot SPECIALISE ‘RandomGen.getRandomPrimFromRandomGenState’
      because its definition has no INLINE/INLINABLE pragma
      (or its defining module ‘Data.Random.Source.RandomGen’
       was compiled without -O)
   |
62 | {-# SPECIALIZE RandomGen.getRandomPrimFromRandomGenState :: Prim a -> State StdGen a #-}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ghc: panic! (the 'impossible' happened)
  (GHC version 8.4.4 for x86_64-unknown-linux):
        dsImpSpecs
  getRandomPrimFromRandomGenState
  Call stack:
      CallStack (from HasCallStack):
        callStackDoc, called at compiler/utils/Outputable.hs:1150:37 in ghc:Outputable
        pprPanic, called at compiler/deSugar/DsBinds.hs:720:28 in ghc:DsBinds

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

~~This patch disables them for old versions of ghc.~~

This patch adds an INLINABLE pragma to the specialized function (as suggested by the warning).