### PR TITLE
prepare for release

### DIFF
--- a/random-fu/changelog.md
+++ b/random-fu/changelog.md
@@ -1,3 +1,7 @@
+* Changes in 0.2.7.7: Update to random-1.2. Revert 0.2.7.6 changes (which added an extra constraint to `Data.Random.Sample.sampleState` and `Data.Random.Sample.sampleStateT`).
+
+* Changes in 0.2.7.4: Compatibility with ghc 8.8.
+
 * Changes in 0.2.7.3: Remove dependence on log-domain. Raise lower bound for base to 4.9.
 
 * Changes in 0.2.7.1: Add PDF instance for Poisson.

--- a/random-fu/random-fu.cabal
+++ b/random-fu/random-fu.cabal
@@ -2,7 +2,7 @@ name:                   random-fu
 version:                0.2.7.7
 stability:              provisional
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.10
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>
@@ -47,6 +47,7 @@ Flag mtl2
 Library
   ghc-options:          -Wall -funbox-strict-fields
   hs-source-dirs:       src
+  default-language:     Haskell2010
   exposed-modules:      Data.Random
                         Data.Random.Distribution
                         Data.Random.Distribution.Bernoulli

--- a/random-source/changelog.md
+++ b/random-source/changelog.md
@@ -1,0 +1,13 @@
+* Changes in 0.3.0.11: Revert 0.3.0.10 changes (which accidentally removed the Random.Source.PureMT module and added an overlapping instance).
+
+* Changes in 0.3.0.8: Add MonadRandom instance for MWC generator and RWS transformer.
+
+* Changes in 0.3.0.6: Fixed overzealous fix in 0.3.0.5.  The people responsible for sacking the people who have been sacked, etc., have been sacked.
+
+* Changes in 0.3.0.5: Renamed some internal modules and accidentally some external ones too.  Whoops.  Please don't use this version, it will only end in tears.
+
+* Changes in 0.3.0.4: Fixed a typo that broke building with MTL-1
+
+* Changes in 0.3.0.3: Fixes for GHC's deprecation of Foreign.unsafePerformIO
+
+* Changes in 0.3.0.2: Fixes for GHC 7.2.*'s crazy Template Haskell changes.

--- a/random-source/random-source.cabal
+++ b/random-source/random-source.cabal
@@ -18,21 +18,10 @@ description:            Random number generation based on entropy sources
                         \"completing\" partial implementations, making it
                         easy to define new entropy sources in a way that
                         is naturally forward-compatible.
-                        .
-                        Changes in 0.3.0.6: Fixed overzealous fix in 0.3.0.5.  The people responsible for sacking the people who have been sacked, etc., have been sacked.
-                        .
-                        Changes in 0.3.0.5: Renamed some internal modules and accidentally some external ones too.  Whoops.  Please don't use this version, it will only end in tears.
-                        .
-                        Changes in 0.3.0.4: Fixed a typo that broke building
-                        with MTL-1
-                        .
-                        Changes in 0.3.0.3: Fixes for GHC's deprecation
-                        of Foreign.unsafePerformIO
-                        .
-                        Changes in 0.3.0.2: Fixes for GHC 7.2.*'s crazy
-                        Template Haskell changes.
 
 tested-with:            GHC == 7.4.2, GHC == 7.6.1
+
+extra-source-files:     changelog.md
 
 source-repository head
   type:                 git

--- a/random-source/random-source.cabal
+++ b/random-source/random-source.cabal
@@ -2,7 +2,7 @@ name:                   random-source
 version:                0.3.0.11
 stability:              provisional
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.10
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>
@@ -48,6 +48,7 @@ Flag mtl2
 Library
   ghc-options:          -Wall
   hs-source-dirs:       src
+  default-language:     Haskell2010
   exposed-modules:      Data.Random.Source
                         Data.Random.Source.IO
                         Data.Random.Source.PureMT

--- a/rvar/changelog.md
+++ b/rvar/changelog.md
@@ -1,0 +1,9 @@
+* Changes in 0.2.0.6: None. (Pacify Hackage.)
+
+* Changes in 0.2.0.4: Update for GHC 8.8.
+
+* Changes in 0.2.0.3: Version bump for transformers dependency.
+
+* Changes in 0.2.0.2: Version bump for transformers dependency.
+
+* Changes in 0.2.0.1: Version bump for transformers dependency.

--- a/rvar/rvar.cabal
+++ b/rvar/rvar.cabal
@@ -1,8 +1,8 @@
 name:                   rvar
-version:                0.2.0.4
+version:                0.2.0.6
 stability:              stable
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.10
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>
@@ -44,6 +44,7 @@ Flag mtl2
 Library
   ghc-options:          -Wall
   hs-source-dirs:       src
+  default-language:     Haskell2010
   exposed-modules:      Data.RVar
 
   if flag(mtl2)

--- a/rvar/rvar.cabal
+++ b/rvar/rvar.cabal
@@ -26,12 +26,11 @@ description:            Random number generation based on modeling random
                         comparable to other Haskell libraries, but still
                         a fair bit slower than straight C implementations of
                         the same algorithms.
-                        .
-                        Changes in 0.2.0.1:  Version bump for transformers
-                        dependency.
 
 tested-with:            GHC == 6.8.3, GHC == 6.10.4, GHC == 6.12.3,
                         GHC == 7.0.4, GHC == 7.2.1, GHC == 7.2.2
+
+extra-source-files:     changelog.md
 
 source-repository head
   type:                 git


### PR DESCRIPTION
* restore changes that are in the latest Hackage releases (Hackage requires a `default-language` tag)
* add changelogs

Note that I don't have maintainer access on Hackage, so currently I cannot release these myself.

Also, is there anything more to the release process than uploading the packages to Hackage?

And I still can't look at CircleCI without logging in (and I still don't want to do that, there's simply no justification for giving them write access to my repos)