### PR TITLE
Remove trailing whitespaces and switch to newer lts

### DIFF
--- a/random-fu/src/Data/Random/Distribution.hs
+++ b/random-fu/src/Data/Random/Distribution.hs
@@ -13,7 +13,7 @@ import Data.Random.RVar
 -- > data Normal a
 -- >     = StdNormal
 -- >     | Normal a a
--- 
+--
 -- Where the two parameters of the 'Normal' data constructor are the mean and
 -- standard deviation of the random variable, respectively.  To make use of
 -- the 'Normal' type, one can convert it to an 'rvar' and manipulate it or
@@ -21,39 +21,39 @@ import Data.Random.RVar
 --
 -- > x <- sample (rvar (Normal 10 2))
 -- > x <- sample (Normal 10 2)
--- 
+--
 -- A 'Distribution' is typically more transparent than an 'RVar'
--- but less composable (precisely because of that transparency).  There are 
+-- but less composable (precisely because of that transparency).  There are
 -- several practical uses for types implementing 'Distribution':
--- 
--- * Typically, a 'Distribution' will expose several parameters of a standard 
+--
+-- * Typically, a 'Distribution' will expose several parameters of a standard
 -- mathematical model of a probability distribution, such as mean and std deviation for
 -- the normal distribution.  Thus, they can be manipulated analytically using
 -- mathematical insights about the distributions they represent.  For example,
 -- a collection of bernoulli variables could be simplified into a (hopefully) smaller
 -- collection of binomial variables.
--- 
+--
 -- * Because they are generally just containers for parameters, they can be
--- easily serialized to persistent storage or read from user-supplied 
+-- easily serialized to persistent storage or read from user-supplied
 -- configurations (eg, initialization data for a simulation).
--- 
+--
 -- * If a type additionally implements the 'CDF' subclass, which extends
 -- 'Distribution' with a cumulative density function, an arbitrary random
 -- variable 'x' can be tested against the distribution by testing
 -- @fmap (cdf dist) x@ for uniformity.
--- 
+--
 -- On the other hand, most 'Distribution's will not be closed under all the
 -- same operations as 'RVar' (which, being a monad, has a fully turing-complete
--- internal computational model).  The sum of two uniformly-distributed 
--- variables, for example, is not uniformly distributed.  To support general 
--- composition, the 'Distribution' class defines a function 'rvar' to 
--- construct the more-abstract and more-composable 'RVar' representation 
+-- internal computational model).  The sum of two uniformly-distributed
+-- variables, for example, is not uniformly distributed.  To support general
+-- composition, the 'Distribution' class defines a function 'rvar' to
+-- construct the more-abstract and more-composable 'RVar' representation
 -- of a random variable.
 class Distribution d t where
     -- |Return a random variable with this distribution.
     rvar :: d t -> RVar t
     rvar = rvarT
-    
+
     -- |Return a random variable with the given distribution, pre-lifted to an arbitrary 'RVarT'.
     -- Any arbitrary 'RVar' can also be converted to an 'RVarT m' for an arbitrary 'm', using
     -- either 'lift' or 'sample'.
@@ -66,7 +66,7 @@ class Distribution d t => PDF d t where
     pdf d = exp . logPdf d
     logPdf :: d t -> t -> Double
     logPdf d = log . pdf d
-    
+
 
 class Distribution d t => CDF d t where
     -- |Return the cumulative distribution function of this distribution.
@@ -76,19 +76,19 @@ class Distribution d t => CDF d t where
     --
     -- In the case where 't' is an instance of Ord, 'cdf' should correspond
     -- to the CDF with respect to that order.
-    -- 
+    --
     -- In other cases, 'cdf' is only required to satisfy the following law:
     -- @fmap (cdf d) (rvar d)@
     -- must be uniformly distributed over (0,1).  Inclusion of either endpoint is optional,
     -- though the preferred range is (0,1].
-    -- 
-    -- Note that this definition requires that  'cdf' for a product type 
-    -- should _not_ be a joint CDF as commonly defined, as that definition 
+    --
+    -- Note that this definition requires that  'cdf' for a product type
+    -- should _not_ be a joint CDF as commonly defined, as that definition
     -- violates both conditions.
     -- Instead, it should be a univariate CDF over the product type.  That is,
     -- it should represent the CDF with respect to the lexicographic order
     -- of the product.
-    -- 
+    --
     -- The present specification is probably only really useful for testing
     -- conformance of a variable to its target distribution, and I am open to
     -- suggestions for more-useful specifications (especially with regard to

--- a/random-fu/src/Data/Random/Distribution/Bernoulli.hs
+++ b/random-fu/src/Data/Random/Distribution/Bernoulli.hs
@@ -57,7 +57,7 @@ generalBernoulliCDF gte f t p x
 
 newtype Bernoulli b a = Bernoulli b
 
-instance (Fractional b, Ord b, Distribution StdUniform b) 
+instance (Fractional b, Ord b, Distribution StdUniform b)
        => Distribution (Bernoulli b) Bool
     where
         rvarT (Bernoulli p) = boolBernoulli p
@@ -67,7 +67,7 @@ instance (Distribution (Bernoulli b) Bool, Real b)
         cdf  (Bernoulli p) = boolBernoulliCDF p
 
 $( replicateInstances ''Int integralTypes [d|
-        instance Distribution (Bernoulli b) Bool 
+        instance Distribution (Bernoulli b) Bool
               => Distribution (Bernoulli b) Int
               where
                   rvarT (Bernoulli p) = generalBernoulli 0 1 p
@@ -78,7 +78,7 @@ $( replicateInstances ''Int integralTypes [d|
     |] )
 
 $( replicateInstances ''Float realFloatTypes [d|
-        instance Distribution (Bernoulli b) Bool 
+        instance Distribution (Bernoulli b) Bool
               => Distribution (Bernoulli b) Float
               where
                   rvarT (Bernoulli p) = generalBernoulli 0 1 p
@@ -89,11 +89,11 @@ $( replicateInstances ''Float realFloatTypes [d|
     |] )
 
 instance (Distribution (Bernoulli b) Bool, Integral a)
-       => Distribution (Bernoulli b) (Ratio a)   
+       => Distribution (Bernoulli b) (Ratio a)
        where
            rvarT (Bernoulli p) = generalBernoulli 0 1 p
 instance (CDF (Bernoulli b) Bool, Integral a)
-       => CDF (Bernoulli b) (Ratio a)   
+       => CDF (Bernoulli b) (Ratio a)
        where
            cdf  (Bernoulli p) = generalBernoulliCDF (>=) 0 1 p
 instance (Distribution (Bernoulli b) Bool, RealFloat a)

--- a/random-fu/src/Data/Random/Distribution/Dirichlet.hs
+++ b/random-fu/src/Data/Random/Distribution/Dirichlet.hs
@@ -18,7 +18,7 @@ fractionalDirichlet [_] = return [1]
 fractionalDirichlet as = do
     xs <- sequence [gammaT a 1 | a <- as]
     let total = foldl1' (+) xs
-    
+
     return (map (* recip total) xs)
 
 dirichlet :: Distribution Dirichlet [a] => [a] -> RVar [a]

--- a/random-fu/src/Data/Random/Distribution/F.hs
+++ b/random-fu/src/Data/Random/Distribution/F.hs
@@ -17,4 +17,3 @@ instance (Fractional t, Distribution Beta t) => Distribution F t where
         let p' = fromIntegral p; q' = fromIntegral q
         y <- betaT (0.5*p') (0.5*q')
         return (q'/p' * y/(1-y))
-    

--- a/random-fu/src/Data/Random/Distribution/Gamma.hs
+++ b/random-fu/src/Data/Random/Distribution/Gamma.hs
@@ -9,10 +9,10 @@
 module Data.Random.Distribution.Gamma
     ( Gamma(..)
     , gamma, gammaT
-    
+
     , Erlang(..)
     , erlang, erlangT
-    
+
     , mtGamma
     ) where
 
@@ -31,10 +31,10 @@ import Numeric.SpecFunctions
 {-# SPECIALIZE mtGamma :: Float  -> Float  -> RVarT m Float  #-}
 mtGamma
     :: (Floating a, Ord a,
-        Distribution StdUniform a, 
+        Distribution StdUniform a,
         Distribution Normal a)
     => a -> a -> RVarT m a
-mtGamma a b 
+mtGamma a b
     | a < 1     = do
         u <- stdUniformT
         mtGamma (1+a) $! (b * u ** recip a)
@@ -42,11 +42,11 @@ mtGamma a b
     where
         !d = a - fromRational (1%3)
         !c = recip (sqrt (9*d))
-        
+
         go = do
             x <- stdNormalT
             let !v   = 1 + c*x
-            
+
             if v <= 0
                 then go
                 else do
@@ -89,4 +89,3 @@ instance (Integral a, Floating b, Ord b, Distribution Normal b, Distribution Std
 
 instance (Integral a, Real b, Distribution (Erlang a) b) => CDF (Erlang a) b where
     cdf (Erlang a) x = incompleteGamma (fromIntegral a) (realToFrac x)
-

--- a/random-fu/src/Data/Random/Distribution/Multinomial.hs
+++ b/random-fu/src/Data/Random/Distribution/Multinomial.hs
@@ -24,9 +24,9 @@ instance (Num a, Eq a, Fractional p, Distribution (Binomial p) a) => Distributio
             go n (p:ps) (psum:psums) f = do
                 x <- binomialT n (p / psum)
                 go (n-x) ps psums (f . (x:))
-            
+
             go _ _ _ _ = error "rvar/Multinomial: programming error! this case should be impossible!"
-            
+
             -- less wasteful version of (map sum . tails)
             tailSums [] = [0]
             tailSums (x:xs) = case tailSums xs of

--- a/random-fu/src/Data/Random/Distribution/Normal.hs
+++ b/random-fu/src/Data/Random/Distribution/Normal.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE
     MultiParamTypeClasses, FlexibleInstances, FlexibleContexts,
-    UndecidableInstances, ForeignFunctionInterface, BangPatterns, 
+    UndecidableInstances, ForeignFunctionInterface, BangPatterns,
     RankNTypes
   #-}
 
@@ -10,13 +10,13 @@ module Data.Random.Distribution.Normal
     ( Normal(..)
     , normal, normalT
     , stdNormal, stdNormalT
-    
+
     , doubleStdNormal
     , floatStdNormal
     , realFloatStdNormal
-    
+
     , normalTail
-    
+
     , normalPair
     , boxMullerNormalPair
     , knuthPolarNormalPair
@@ -44,7 +44,7 @@ normalPair = boxMullerNormalPair
 
 -- |A random variable that produces a pair of independent
 -- normally-distributed values, computed using the Box-Muller method.
--- This algorithm is slightly slower than Knuth's method but using a 
+-- This algorithm is slightly slower than Knuth's method but using a
 -- constant amount of entropy (Knuth's method is a rejection method).
 -- It is also slightly more general (Knuth's method require an 'Ord'
 -- instance).
@@ -55,27 +55,27 @@ boxMullerNormalPair = do
     t <- stdUniform
     let r = sqrt (-2 * log u)
         theta = (2 * pi) * t
-        
+
         x = r * cos theta
         y = r * sin theta
     return (x,y)
 
 -- |A random variable that produces a pair of independent
 -- normally-distributed values, computed using Knuth's polar method.
--- Slightly faster than 'boxMullerNormalPair' when it accepts on the 
+-- Slightly faster than 'boxMullerNormalPair' when it accepts on the
 -- first try, but does not always do so.
 {-# INLINE knuthPolarNormalPair #-}
 knuthPolarNormalPair :: (Floating a, Ord a, Distribution Uniform a) => RVar (a,a)
 knuthPolarNormalPair = do
     v1 <- uniform (-1) 1
     v2 <- uniform (-1) 1
-    
+
     let s = v1*v1 + v2*v2
     if s >= 1
         then knuthPolarNormalPair
         else return $ if s == 0
             then (0,0)
-            else let scale = sqrt (-2 * log s / s) 
+            else let scale = sqrt (-2 * log s / s)
                   in (v1 * scale, v2 * scale)
 
 -- |Draw from the tail of a normal distribution (the region beyond the provided value)
@@ -110,7 +110,7 @@ normalFInv :: Floating a => a -> a
 normalFInv y  = sqrt ((-2) * log y)
 -- | integral of 'normalF'
 normalFInt :: (Floating a, Erf a, Ord a) => a -> a
-normalFInt x 
+normalFInt x
     | x <= 0    = 0
     | otherwise = normalFVol * erf (x * sqrt 0.5)
 -- | volume of 'normalF'
@@ -120,8 +120,8 @@ normalFVol = sqrt (0.5 * pi)
 -- |A random variable sampling from the standard normal distribution
 -- over any 'RealFloat' type (subject to the rest of the constraints -
 -- it builds and uses a 'Ziggurat' internally, which requires the 'Erf'
--- class).  
--- 
+-- class).
+--
 -- Because it computes a 'Ziggurat', it is very expensive to use for
 -- just one evaluation, or even for multiple evaluations if not used and
 -- reused monomorphically (to enable the ziggurat table to be let-floated
@@ -135,10 +135,10 @@ normalFVol = sqrt (0.5 * pi)
 -- @Distribution Normal@ instance declaration.
 realFloatStdNormal :: (RealFloat a, Erf a, Distribution Uniform a) => RVarT m a
 realFloatStdNormal = runZiggurat (normalZ p getIU `asTypeOf` (undefined :: Ziggurat V.Vector a))
-    where 
+    where
         p :: Int
         p = 6
-        
+
         getIU :: (Num a, Distribution Uniform a) => RVarT m (Int, a)
         getIU = do
             i <- getRandomWord8
@@ -159,12 +159,12 @@ doubleStdNormalV = 2.4567663515413507e-3
 
 {-# NOINLINE doubleStdNormalZ #-}
 doubleStdNormalZ :: Ziggurat UV.Vector Double
-doubleStdNormalZ = mkZiggurat_ True 
-        normalF normalFInv 
-        doubleStdNormalC doubleStdNormalR doubleStdNormalV 
+doubleStdNormalZ = mkZiggurat_ True
+        normalF normalFInv
+        doubleStdNormalC doubleStdNormalR doubleStdNormalV
         getIU
         (normalTail doubleStdNormalR)
-    where 
+    where
         getIU :: RVarT m (Int, Double)
         getIU = do
             !w <- getRandomWord64
@@ -185,9 +185,9 @@ floatStdNormalV = 2.4567663515413507e-3
 
 {-# NOINLINE floatStdNormalZ #-}
 floatStdNormalZ :: Ziggurat UV.Vector Float
-floatStdNormalZ = mkZiggurat_ True 
-        normalF normalFInv 
-        floatStdNormalC floatStdNormalR floatStdNormalV 
+floatStdNormalZ = mkZiggurat_ True
+        normalF normalFInv
+        floatStdNormalC floatStdNormalR floatStdNormalV
         getIU
         (normalTail floatStdNormalR)
     where

--- a/random-fu/src/Data/Random/Distribution/Rayleigh.hs
+++ b/random-fu/src/Data/Random/Distribution/Rayleigh.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE
-        MultiParamTypeClasses, 
+        MultiParamTypeClasses,
         FlexibleInstances, FlexibleContexts,
         UndecidableInstances
   #-}
@@ -19,7 +19,7 @@ floatingRayleigh s = do
 
 -- |The rayleigh distribution with a specified mode (\"sigma\") parameter.
 -- Its mean will be @sigma*sqrt(pi/2)@ and its variance will be @sigma^2*(4-pi)/2@
--- 
+--
 -- (therefore if you want one with a particular mean @m@, @sigma@ should be @m*sqrt(2/pi)@)
 newtype Rayleigh a = Rayleigh a
 

--- a/random-fu/src/Data/Random/Distribution/Triangular.hs
+++ b/random-fu/src/Data/Random/Distribution/Triangular.hs
@@ -52,7 +52,7 @@ triangularCDF a b c x
     = realToFrac (1 - (c - x)^(2 :: Int) / ((c - a) * (c - b)))
     | otherwise
     = 1
-    
+
 instance (RealFloat a, Ord a, Distribution StdUniform a) => Distribution Triangular a where
     rvarT (Triangular a b c) = floatingTriangular a b c
 instance (RealFrac a, Distribution Triangular a) => CDF Triangular a where

--- a/random-fu/src/Data/Random/Internal/Find.hs
+++ b/random-fu/src/Data/Random/Internal/Find.hs
@@ -19,7 +19,7 @@ findMin = findMinFrom 0 1
 -- specified point with the specified stepsize, performs an exponential
 -- search out from there until it finds an interval bracketing the
 -- change-point of the predicate, and then performs a bisection search
--- to isolate the change point.  Note that infinitely-divisible domains 
+-- to isolate the change point.  Note that infinitely-divisible domains
 -- such as 'Rational' cannot be searched by this function because it does
 -- not terminate until it reaches a point where further subdivision of the
 -- interval has no effect.
@@ -33,31 +33,31 @@ findMinFrom z0 step1 p
         -- a feasible answer
         fixZero 0 = 0
         fixZero z = z
-        
+
         -- preconditions:
         -- not (p l)
         -- 0 <= l < x
-        ascend l x 
+        ascend l x
             | p x       = bisect l x
             | otherwise = ascend x $! 2*x-z0
-        
+
         -- preconditions:
         -- p h
         -- x < h <= 0
-        descend x h 
+        descend x h
             | p x       = (descend $! 2*x-z0) x
             | otherwise = bisect x h
-        
+
         -- preconditions:
         -- not (p l)
         -- p h
         -- l <= h
-        bisect l h 
+        bisect l h
             | l /< h    = h
             | l /< mid || mid /< h
             = if p mid then mid else h
             | p mid     = bisect l mid
             | otherwise = bisect mid h
-            where 
+            where
                 a /< b = not (a < b)
                 mid = (l+h)*0.5

--- a/random-fu/src/Data/Random/Internal/Fixed.hs
+++ b/random-fu/src/Data/Random/Internal/Fixed.hs
@@ -35,7 +35,7 @@ resolutionOf2 x = resolution (res x)
 -- |The 'Fixed' type doesn't expose its constructors, but I need a way to
 -- convert them to and from their raw representation in order to sample
 -- them.  As long as 'Fixed' is a newtype wrapping 'Integer', 'mkFixed' and
--- 'unMkFixed' as defined here will work.  Both are implemented using 
+-- 'unMkFixed' as defined here will work.  Both are implemented using
 -- 'unsafeCoerce'.
 mkFixed :: Integer -> Fixed r
 mkFixed = unsafeCoerce

--- a/random-fu/src/Data/Random/Internal/TH.hs
+++ b/random-fu/src/Data/Random/Internal/TH.hs
@@ -6,12 +6,12 @@
 -- to cover large numbers of types.  I'm doing that rather than using
 -- class contexts because most Distribution instances need to cover
 -- multiple classes (such as Enum, Integral and Fractional) and that
--- can't be done easily because of overlap.  
--- 
--- I experimented a bit with a convoluted type-level classification 
--- scheme, but I think this is simpler and easier to understand.  It 
--- makes the haddock docs more cluttered because of the combinatorial 
--- explosion of instances, but overall I think it's just more sane than 
+-- can't be done easily because of overlap.
+--
+-- I experimented a bit with a convoluted type-level classification
+-- scheme, but I think this is simpler and easier to understand.  It
+-- makes the haddock docs more cluttered because of the combinatorial
+-- explosion of instances, but overall I think it's just more sane than
 -- anything else I've come up with yet.
 module Data.Random.Internal.TH
     ( replicateInstances
@@ -27,7 +27,7 @@ import Control.Monad
 
 -- |Names of standard 'Integral' types
 integralTypes :: [Name]
-integralTypes = 
+integralTypes =
     [ ''Integer
     , ''Int,  ''Int8,  ''Int16,  ''Int32,  ''Int64
     , ''Word, ''Word8, ''Word16, ''Word32, ''Word64
@@ -53,17 +53,17 @@ replaceName x y z
 -- 'Dec's in @decls@ and substitute every instance of the 'Name' @standin@ with
 -- each 'Name' in @types@, producing one copy of the 'Dec's in @decls@ for every
 -- 'Name' in @types@.
--- 
+--
 -- For example, 'Data.Random.Distribution.Uniform' has the following bit of TH code:
--- 
+--
 -- @ $( replicateInstances ''Int integralTypes [d|                                                  @
--- 
+--
 -- @       instance Distribution Uniform Int   where rvar (Uniform a b) = integralUniform a b       @
--- 
+--
 -- @       instance CDF Uniform Int            where cdf  (Uniform a b) = integralUniformCDF a b    @
--- 
+--
 -- @   |])                                                                                          @
--- 
+--
 -- This code takes those 2 instance declarations and creates identical ones for
 -- every type named in 'integralTypes'.
 replicateInstances :: (Monad m, Data t) => Name -> [Name] -> m [t] -> m [t]
@@ -76,4 +76,3 @@ replicateInstances standin types getDecls = liftM concat $ sequence
             ]
     | t <- types
     ]
-

--- a/random-fu/src/Data/Random/Lift.hs
+++ b/random-fu/src/Data/Random/Lift.hs
@@ -19,10 +19,10 @@ import qualified Control.Monad.Identity as MTL
 -- For instances where 'm' and 'n' have 'return'/'pure' defined,
 -- these instances must satisfy
 -- @lift (return x) == return x@.
--- 
+--
 -- This form of 'lift' has an extremely general type and is used primarily to
 -- support 'sample'.  Its excessive generality is the main reason it's not
--- exported from "Data.Random".  'RVarT' is, however, an instance of 
+-- exported from "Data.Random".  'RVarT' is, however, an instance of
 -- 'T.MonadTrans', which in most cases is the preferred way
 -- to do the lifting.
 class Lift m n where
@@ -67,4 +67,3 @@ instance T.MonadTrans t => Lift MTL.Identity (t MTL.Identity) where
     lift = T.lift
 
 #endif
-

--- a/random-fu/src/Data/Random/List.hs
+++ b/random-fu/src/Data/Random/List.hs
@@ -28,11 +28,11 @@ shuffleT :: [a] -> RVarT m [a]
 shuffleT [] = return []
 shuffleT xs = do
     is <- zipWithM (\_ i -> uniformT 0 i) (tail xs) [1..]
-    
+
     return (SRS.shuffle xs (reverse is))
 
 -- | A random variable that shuffles a list of a known length (or a list
--- prefix of the specified length). Useful for shuffling large lists when 
+-- prefix of the specified length). Useful for shuffling large lists when
 -- the length is known in advance.  Avoids needing to traverse the list to
 -- discover its length.  Each ordering has equal probability.
 shuffleN :: Int -> [a] -> RVar [a]
@@ -53,4 +53,3 @@ shuffleNofMT n m xs
         is <- sequence [uniformT 0 i | i <- take n [m-1, m-2 ..1]]
         return (take n $ SRS.shuffle (take m xs) is)
 shuffleNofMT _ _ _ = error "shuffleNofMT: negative length specified"
-

--- a/random-fu/src/Data/Random/RVar.hs
+++ b/random-fu/src/Data/Random/RVar.hs
@@ -8,7 +8,7 @@ import Data.Random.Lift
 import Data.Random.Internal.Source
 import Data.RVar hiding (runRVarT)
 
--- |Like 'runRVarTWith', but using an implicit lifting (provided by the 
+-- |Like 'runRVarTWith', but using an implicit lifting (provided by the
 -- 'Lift' class)
 runRVarT :: (Lift n m, RandomSource m s) => RVarT n a -> s -> m a
 runRVarT = runRVarTWith lift

--- a/random-fu/src/Data/Random/Sample.hs
+++ b/random-fu/src/Data/Random/Sample.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE
         MultiParamTypeClasses,
-        FlexibleInstances, FlexibleContexts, 
+        FlexibleInstances, FlexibleContexts,
         IncoherentInstances
   #-}
 
@@ -8,7 +8,7 @@
 
 module Data.Random.Sample where
 
-import Control.Monad.State 
+import Control.Monad.State
 import Data.Random.Distribution
 import Data.Random.Lift
 import Data.Random.RVar

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE
     RankNTypes,
     MultiParamTypeClasses,
-    FlexibleInstances, 
+    FlexibleInstances,
     GADTs,
     ScopedTypeVariables,
     CPP
@@ -25,10 +25,10 @@ module Data.RVar
         , getRandomDouble
         , getRandomNByteInteger
         )
-    
+
     , RVar
     , runRVar, sampleRVar
-    
+
     , RVarT
     , runRVarT, sampleRVarT
     , runRVarTWith, sampleRVarTWith
@@ -45,36 +45,36 @@ import qualified Control.Monad.IO.Class as T
 import qualified Control.Monad.Trans as MTL
 import qualified Data.Functor.Identity as T
 
--- |An opaque type modeling a \"random variable\" - a value 
--- which depends on the outcome of some random event.  'RVar's 
+-- |An opaque type modeling a \"random variable\" - a value
+-- which depends on the outcome of some random event.  'RVar's
 -- can be conveniently defined by an imperative-looking style:
--- 
+--
 -- > normalPair =  do
 -- >     u <- stdUniform
 -- >     t <- stdUniform
 -- >     let r = sqrt (-2 * log u)
 -- >         theta = (2 * pi) * t
--- >         
+-- >
 -- >         x = r * cos theta
 -- >         y = r * sin theta
 -- >     return (x,y)
--- 
+--
 -- OR by a more applicative style:
--- 
+--
 -- > logNormal = exp <$> stdNormal
 --
 -- Once defined (in any style), there are several ways to sample 'RVar's:
--- 
+--
 -- * In a monad, using a 'RandomSource':
--- 
+--
 -- > runRVar (uniform 1 100) DevRandom :: IO Int
--- 
+--
 -- * In a monad, using a 'MonadRandom' instance:
 --
 -- > sampleRVar (uniform 1 100) :: State PureMT Int
--- 
+--
 -- * As a pure function transforming a functional RNG:
--- 
+--
 -- > sampleState (uniform 1 100) :: StdGen -> (Int, StdGen)
 --
 -- (where @sampleState = runState . sampleRVar@)
@@ -92,21 +92,21 @@ sampleRVar = sampleRVarTWith (return . T.runIdentity)
 -- |A random variable with access to operations in an underlying monad.  Useful
 -- examples include any form of state for implementing random processes with hysteresis,
 -- or writer monads for implementing tracing of complicated algorithms.
--- 
+--
 -- For example, a simple random walk can be implemented as an 'RVarT' 'IO' value:
 --
 -- > rwalkIO :: IO (RVarT IO Double)
 -- > rwalkIO d = do
 -- >     lastVal <- newIORef 0
--- >     
+-- >
 -- >     let x = do
 -- >             prev    <- lift (readIORef lastVal)
 -- >             change  <- rvarT StdNormal
--- >             
+-- >
 -- >             let new = prev + change
 -- >             lift (writeIORef lastVal new)
 -- >             return new
--- >         
+-- >
 -- >     return x
 --
 -- To run the random walk it must first be initialized, after which it can be sampled as usual:
@@ -119,20 +119,20 @@ sampleRVar = sampleRVarTWith (return . T.runIdentity)
 --
 -- The same random-walk process as above can be implemented using MTL types
 -- as follows (using @import Control.Monad.Trans as MTL@):
--- 
+--
 -- > rwalkState :: RVarT (State Double) Double
 -- > rwalkState = do
 -- >     prev <- MTL.lift get
 -- >     change  <- rvarT StdNormal
--- >     
+-- >
 -- >     let new = prev + change
 -- >     MTL.lift (put new)
 -- >     return new
--- 
+--
 -- Invocation is straightforward (although a bit noisy) if you're used to MTL:
--- 
+--
 -- > rwalk :: Int -> Double -> StdGen -> ([Double], StdGen)
--- > rwalk count start gen = 
+-- > rwalk count start gen =
 -- >     flip evalState start .
 -- >         flip runStateT gen .
 -- >             sampleRVarTWith MTL.lift $
@@ -146,8 +146,8 @@ sampleRVarT :: MonadRandom m => RVarT m a -> m a
 sampleRVarT = sampleRVarTWith id
 
 -- | \"Runs\" an 'RVarT', sampling the random variable it defines.
--- 
--- The first argument lifts the base monad into the sampling monad.  This 
+--
+-- The first argument lifts the base monad into the sampling monad.  This
 -- operation must obey the \"monad transformer\" laws:
 --
 -- > lift . return = return
@@ -166,9 +166,9 @@ sampleRVarT = sampleRVarTWith id
 --
 -- The ability to lift is very important - without it, every 'RVar' would have
 -- to either be given access to the full capability of the monad in which it
--- will eventually be sampled (which, incidentally, would also have to be 
+-- will eventually be sampled (which, incidentally, would also have to be
 -- monomorphic so you couldn't sample one 'RVar' in more than one monad)
--- or functions manipulating 'RVar's would have to use higher-ranked 
+-- or functions manipulating 'RVar's would have to use higher-ranked
 -- types to enforce the same kind of isolation and polymorphism.
 {-# INLINE runRVarTWith #-}
 runRVarTWith :: forall m n s a. RandomSource m s => (forall t. n t -> m t) -> RVarT n a -> s -> m a
@@ -176,7 +176,7 @@ runRVarTWith liftN (RVarT m) src = runPromptT return bindP bindN m
     where
         bindP :: forall t. (Prim t -> (t -> m a) -> m a)
         bindP prim cont = getRandomPrimFrom src prim >>= cont
-        
+
         bindN :: forall t. n t -> (t -> m a) -> m a
         bindN nExp cont = liftN nExp >>= cont
 
@@ -186,7 +186,7 @@ sampleRVarTWith liftN (RVarT m) = runPromptT return bindP bindN m
     where
         bindP :: forall t. (Prim t -> (t -> m a) -> m a)
         bindP prim cont = getRandomPrim prim >>= cont
-        
+
         bindN :: forall t. n t -> (t -> m a) -> m a
         bindN nExp cont = liftN nExp >>= cont
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.7
+resolver: lts-16.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -41,7 +41,11 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+- random-1.2.0@sha256:30d72df4cc1d2fe2d445c88f0ee9d21965af7ce86660c43a6c32a6a1d90d51c9,6094
+- flexible-defaults-0.0.3@sha256:6a7ab000561e1075003cb1053dfbbb4020ae2b02916776d1479c9c3fc82f5d0d,2508
+- splitmix-0.1.0.3@sha256:fc3aae74c467f4b608050bef53aec17904a618731df9407e655d8f3bf8c32d5c,6049
+- mwc-random-0.15.0.1@sha256:841c86f132c45cb81116e1d3a8a150cecc27820c2b4e38f8cf86e3fe7735c2ab,3370
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/tests/speed/Bench.hs
+++ b/tests/speed/Bench.hs
@@ -113,14 +113,14 @@ main = do
 --                    xs <- stToIO $ replicateM count (MWC.normal src)
 --                    return $ sum' (xs :: [Double])
 --                ]
-            , bgroup "uniformVector"
-                [ bench "Double" $ nfIO $ do
-                    src <- newGenIO
-                    xs <- stToIO $ MWC.uniformVector src count
-                    -- unboxed, so don't need to force it, but we sum it
-                    -- anyway to make the comparison fair between other tests
-                    return $ (Vec.sum xs :: Double)
-                ]
+            -- , bgroup "uniformVector"
+            --     [ bench "Double" $ nfIO $ do
+            --         src <- newGenIO
+            --         xs <- stToIO $ MWC.uniformVector src count
+            --         -- unboxed, so don't need to force it, but we sum it
+            --         -- anyway to make the comparison fair between other tests
+            --         return $ (Vec.sum xs :: Double)
+            --     ]
             ]
 
         , bench "baseline sum" $ nf sum' [1..fromIntegral count :: Double]

--- a/tests/speed/speed-tests.cabal
+++ b/tests/speed/speed-tests.cabal
@@ -12,7 +12,7 @@ description:            Various benchmarks for the random-fu library.
 
 flag split-random-fu
 
-executable random-fu-bench
+benchmark random-fu-bench
   type:             exitcode-stdio-1.0
   main-is:              Bench.hs
   build-depends:        base >= 4, criterion, MonadRandom, mtl,


### PR DESCRIPTION
Sorry, I can't stand trailing white space, so I decided to clean 'em up. Also I noticed that I did it already for some modules in #67 so I thought I'd create a separate PR just for white space removal, just so I can reduce the diff for an already pretty big PR.