### PR TITLE
Document deprecation

### DIFF
--- a/random-source/README.md
+++ b/random-source/README.md
@@ -1,0 +1,31 @@
+It is better to use the
+[random](https://hackage.haskell.org/package/random "well maintained")
+package and the source of randomness.
+
+Here's what you might have written before:
+
+```
+import qualified Data.Random as Random
+import qualified Data.Random.Distribution.Bernoulli as Bernoulli
+
+main :: IO ()
+main = do
+  x <- Random.sample $ Bernoulli.Bernoulli (0.5 :: Double) :: IO Double
+  print x
+```
+
+And here's what you should write now (but there are many other options):
+
+```
+import qualified System.Random.Stateful as Random.Stateful
+import qualified Data.Random as Random
+import qualified Data.Random.Distribution.Bernoulli as Bernoulli
+import qualified Control.Monad.Reader as Reader
+
+main :: IO ()
+main = do
+  stdgen <- Random.Stateful.newIOGenM =<< Random.Stateful.newStdGen
+  x <- Reader.runReaderT (Random.sample $ Bernoulli.Bernoulli (0.5 :: Double)) stdgen
+        :: IO Double
+  print x
+```

--- a/random-source/random-source.cabal
+++ b/random-source/random-source.cabal
@@ -1,5 +1,5 @@
 name:                   random-source
-version:                0.3.0.12
+version:                0.3.0.13
 stability:              provisional
 
 cabal-version:          >= 1.10
@@ -18,10 +18,13 @@ description:            Random number generation based on entropy sources
                         \"completing\" partial implementations, making it
                         easy to define new entropy sources in a way that
                         is naturally forward-compatible.
+                        Now DEPRECATED: see [README] for further
+                        details.
 
 tested-with:            GHC == 7.4.2, GHC == 7.6.1
 
 extra-source-files:     changelog.md
+                        README.md
 
 source-repository head
   type:                 git

--- a/release.nix
+++ b/release.nix
@@ -1,11 +1,12 @@
 let
 
 myHaskellPackageOverlay = self: super: {
-  myHaskellPackages = super.haskell.packages.ghc8107.override {
+  myHaskellPackages = super.haskell.packages.ghc961.override {
     overrides = hself: hsuper: rec {
       random-fu     =  hself.callPackage  ./random-fu { };
+      random-source =  hself.callPackage ./random-source { };
       rvar          =  hself.callPackage ./rvar { };
-      microstache   = super.haskell.lib.doJailbreak hsuper.microstache;
+      vector-binary-instances = super.haskell.lib.doJailbreak hsuper.vector-binary-instances;
     };
   };
 };

--- a/tests/speed/default.nix
+++ b/tests/speed/default.nix
@@ -1,10 +1,10 @@
-{ mkDerivation, base, criterion, deepseq, mersenne-random-pure64
+{ mkDerivation, base, criterion, deepseq, lib, mersenne-random-pure64
 , MonadRandom, mtl, mwc-random, random, random-fu, random-source
-, stateref, stdenv, vector
+, stateref, vector
 }:
 mkDerivation {
   pname = "speed-tests";
-  version = "0.0.0.1";
+  version = "0.0.0.2";
   src = ./.;
   isLibrary = false;
   isExecutable = true;
@@ -13,5 +13,5 @@ mkDerivation {
     mwc-random random random-fu random-source stateref vector
   ];
   license = "unknown";
-  hydraPlatforms = stdenv.lib.platforms.none;
+  hydraPlatforms = lib.platforms.none;
 }


### PR DESCRIPTION
Better documentation on why `random-source` is deprecated.